### PR TITLE
Allow for negative min_latitude values for bbox in geo_with_ll.py for geocoding

### DIFF
--- a/docker/job-spec.json.slcp2cod
+++ b/docker/job-spec.json.slcp2cod
@@ -2,8 +2,7 @@
   "command":"/home/ops/verdi/ops/slcp2cod/script/slcp2cod_wrapper.sh",
   "imported_worker_files": {
     "/home/ops/.netrc": "/home/ops/.netrc",
-    "/home/ops/.aws": "/home/ops/.aws",
-    "/home/ops/ariamh/conf/settings.conf": "/home/ops/ariamh/conf/settings.conf"
+    "/home/ops/.aws": "/home/ops/.aws"
   },
   "recommended-queues" : [
     "grfn-job_worker-large",

--- a/docker/job-spec.json.slcp2cod_facet
+++ b/docker/job-spec.json.slcp2cod_facet
@@ -2,8 +2,7 @@
   "command":"/home/ops/verdi/ops/slcp2cod/script/slcp2cod_wrapper.sh",
   "imported_worker_files": {
     "/home/ops/.netrc": "/home/ops/.netrc",
-    "/home/ops/.aws": "/home/ops/.aws",
-    "/home/ops/ariamh/conf/settings.conf": "/home/ops/ariamh/conf/settings.conf"
+    "/home/ops/.aws": "/home/ops/.aws"
   },
   "recommended-queues" : [
     "grfn-job_worker-large",

--- a/docker/job-spec.json.slcp2cod_network_selector
+++ b/docker/job-spec.json.slcp2cod_network_selector
@@ -2,8 +2,7 @@
   "command":"/home/ops/verdi/ops/slcp2cod/selection/query.py",
   "imported_worker_files": {
     "/home/ops/.netrc": "/home/ops/.netrc",
-    "/home/ops/.aws": "/home/ops/.aws",
-    "/home/ops/ariamh/conf/settings.conf": "/home/ops/ariamh/conf/settings.conf"
+    "/home/ops/.aws": "/home/ops/.aws"
   },
   "recommended-queues" : [
     "grfn-job_worker-large",

--- a/script/burst_coherence_diff.py
+++ b/script/burst_coherence_diff.py
@@ -280,11 +280,12 @@ if __name__ == '__main__':
         lat_min = np.amin(lat_looked_data)
         lon_max = np.amax(lon_looked_data)
         lon_min = np.amin(lon_looked_data)
-        bbox = "{}/{}/{}/{}".format(lat_min, lat_max, lon_min, lon_max)
+        bbox = [lat_min, lat_max, lon_min, lon_max]
 
         script_dir = os.path.dirname(os.path.realpath(__file__))
         cor_diff_looked_geo = 'diff_cor_%02d_%drlks_%dalks.cor.geo' % (i+1,inps.rlks,inps.alks)
-        cmd = "{}/geo_with_ll.py -input {} -output {} -lat {} -lon {} -bbox {} -ssize {} -rmethod {}".format(script_dir,
+        cmd = "{}/geo_with_ll.py -input {} -output {} -lat {} -lon {} -bbox \"{}\" -ssize {} -rmethod {}".format(
+            script_dir,
             cor_diff_looked, 
             cor_diff_looked_geo,
             lat_looked,

--- a/script/geo_with_ll.py
+++ b/script/geo_with_ll.py
@@ -3,6 +3,7 @@
 #Cunren Liang, JPL/Caltech
 
 
+import ast
 import os
 import sys
 import glob
@@ -105,7 +106,7 @@ def cmdLineParse():
     parser.add_argument('-lon', dest='lon', type=str, required=True,
             help = 'longitude file')
     parser.add_argument('-bbox', dest='bbox', type=str, required=True,
-            help='geocode bounding box (format: S/N/W/E). or you can input master frame pickle file that contains a bounding box')
+            help='geocode bounding box (format: "[S,N,W,E]". or you can input master frame pickle file that contains a bounding box')
     parser.add_argument('-ssize', dest='ssize', type=float, default=1.0,
             help = 'output sample size. default: 1.0 arcsec')
     parser.add_argument('-rmethod', dest='rmethod', type=int, default=1,
@@ -164,7 +165,7 @@ if __name__ == '__main__':
             frame = pickle.load(f)
         bbox = frame.snwe
     else:
-        bbox = [float(val) for val in inps.bbox.split('/')]
+        bbox = [float(val) for val in ast.literal_eval(inps.bbox)]
         if len(bbox) != 4:
             raise Exception('bbox should contain 4 floating point values!')
     print("geocode bounding box:")


### PR DESCRIPTION
Whilst processing the krakatoa AOI (in southern hemisphere) COD job failed to geocode due to python arg_parser unable to parse negative values (with `-`): https://gist.github.com/shitong01/1d6a32d0d84bf5eacc2c5e4b20135e4b#file-stderr-L84-L93

This change makes  `geo_with_ll.py` accept a bbox with list (`[]`) to workaround this problem. Passed in ARIA-SG: https://gist.github.com/shitong01/b56d34b8e6b4ffb1854ba9e2897c4f24#file-stdout-L275