### PR TITLE
Add metadata to COD products

### DIFF
--- a/docker/hysds-io.json.slcp2cod
+++ b/docker/hysds-io.json.slcp2cod
@@ -24,6 +24,21 @@
       "name": "url2",
       "from": "submitter",
       "type": "text"
+    },
+    {
+      "name": "overriding_azimuth_looks",
+      "from": "submitter",
+      "type": "text",
+      "optional": true,
+      "placeholder": "(optional) azimuth looks to override SLCP"
+    },
+    {
+      "name": "overriding_range_looks",
+      "from": "submitter",
+      "type": "text",
+      "optional": true,
+      "placeholder": "(optional) range looks to override SLCP"
+
     }
   ]
 }

--- a/docker/hysds-io.json.slcp2cod_facet
+++ b/docker/hysds-io.json.slcp2cod_facet
@@ -12,7 +12,7 @@
       "name": "project",
       "from": "submitter",
       "type": "enum",
-      "enumerables": ["aria", "grfn", "mem", "urgent-response"]
+      "enumerables": ["grfn", "ariamh", "change_detection","urgent-response","volcano", "mem"]
     },
     {
       "name": "urls",

--- a/docker/hysds-io.json.slcp2cod_network_selector
+++ b/docker/hysds-io.json.slcp2cod_network_selector
@@ -13,7 +13,7 @@
       "name": "project",
       "from": "submitter",
       "type": "enum",
-      "enumerables": ["grfn", "ariamh", "urgent-response", "mem"]
+      "enumerables": ["grfn", "ariamh", "change_detection","urgent-response","volcano", "mem"]
     },
     { 
       "name": "slcp_version",
@@ -24,6 +24,28 @@
       "name": "aoi_name",
       "from": "submitter",
       "type": "text"
+    },
+    {
+      "name": "track_number",
+      "from": "submitter",
+      "type": "text",
+      "optional": true,
+      "placeholder": "(optional) specify track number to be queried"
+    },
+    {
+      "name": "overriding_azimuth_looks",
+      "from": "submitter",
+      "type": "text",
+      "optional": true,
+      "placeholder": "(optional) comma sep. looks across subswaths e.g. 2,2,2"
+    },
+    {
+      "name": "overriding_range_looks",
+      "from": "submitter",
+      "type": "text",
+      "optional": true,
+      "placeholder": "(optional) comma sep. looks across subswaths e.g. 7,8,9"
+
     },
     {
       "name": "minmatch",

--- a/docker/job-spec.json.slcp2cod
+++ b/docker/job-spec.json.slcp2cod
@@ -27,6 +27,14 @@
     { 
       "name": "url2",
       "destination": "localize"
+    },
+    {
+      "name": "overriding_azimuth_looks",
+      "destination": "context"
+    },
+    {
+      "name": "overriding_range_looks",
+      "destination": "context"
     }
   ]
 }

--- a/docker/job-spec.json.slcp2cod_network_selector
+++ b/docker/job-spec.json.slcp2cod_network_selector
@@ -29,6 +29,18 @@
       "destination": "positional"
     },
     {
+      "name": "track_number",
+      "destination": "context"
+    },
+    {
+      "name": "overriding_azimuth_looks",
+      "destination": "context"
+    },
+    {
+      "name": "overriding_range_looks",
+      "destination": "context"
+    },
+    {
       "name": "minmatch",
       "destination": "context"
     },

--- a/script/get_looks.py
+++ b/script/get_looks.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+'''
+Determine looks for COD processing
+'''
+import json
+import argparse
+import os
+
+def main(master_slcp_dir, option):
+    ctx=load_json('_context.json')
+    ctx_key = "overriding_azimuth_looks" if option=="az" else "overriding_range_looks"
+    met_key = "azimuth_looks" if option=="az" else "range_looks"
+    looks = ctx[ctx_key]
+    if looks :
+        print looks
+    else:
+        slcp_met=load_json(os.path.join(master_slcp_dir, os.path.basename(master_slcp_dir) + '.met.json'))
+        print slcp_met[met_key]
+
+def load_json(file):
+    with open(file) as data_file:
+        data = json.load(data_file)
+        data_file.close()
+        return data
+
+def parser():
+    '''
+    Construct a parser to parse arguments
+    @return argparse parser
+    '''
+    parse = argparse.ArgumentParser(description="Determine azimuth and range looks for COD processing")
+    parse.add_argument("master_slcp_dir", help="master SLCP directory")
+    parse.add_argument("look_dir", help="Look direction. Either 'az' for azimuth or 'rn' for range")
+
+
+    return parse
+
+if __name__ == '__main__':
+    args = parser().parse_args()
+    main(args.master_slcp_dir, args.look_dir)

--- a/script/productize.py
+++ b/script/productize.py
@@ -73,7 +73,7 @@ def parse_start_end_times(base):
 
 def create_met(base, fn1, fn2):
     master_slcp_metfile = os.path.join(fn1, fn1 + '.met.json')
-    master_slcp_met = load_file(master_slcp_metfile)
+    master_slcp_met = load_json(master_slcp_metfile)
     met = {}
     met.update(parse_start_end_times(base))
     wanted_slcp_keys = ['trackNumber','frameID', 'swath', 'direction', 'lookDirection', 'spacecraftName']

--- a/script/productize.py
+++ b/script/productize.py
@@ -14,18 +14,18 @@ from shapely.geometry import Polygon, MultiPolygon, mapping
 from shapely.ops import cascaded_union
 from dateutil.parser import parse as dtparse
 
-def main(prod_dir, fn1, fn2):
+def main(prod_dir, fn1, fn2, rlooks, azlooks):
     #exit if there are no products
     if len(os.listdir(prod_dir)) == 0:
         print('Found no products available for publish in workdir: {}'.format(prod_dir))
         raise Exception('No COD products were generated.')
     base = os.path.basename(prod_dir)
-    met = create_met(base, fn1, fn2)
+    met = create_met(base, fn1, fn2, rlooks, azlooks)
     dataset = {}
     dataset_path = os.path.join(prod_dir, '{0}.dataset.json'.format(base))
     met_path = os.path.join(prod_dir, '{0}.met.json'.format(base))
     #get vars
-    dataset['version'] = 'v1.0'
+    dataset['version'] = 'v1.1'
     #try:
     dataset['location'] = get_location(prod_dir)
     #except:
@@ -70,7 +70,7 @@ def parse_start_end_times(base):
     times['sharedtime'] = mid
     return times
 
-def create_met(base, fn1, fn2):
+def create_met(base, fn1, fn2, rlooks, azlooks):
     master_slcp_metfile = os.path.join(fn1, os.path.basename(fn1) + '.met.json')
     master_slcp_met = load_json(master_slcp_metfile)
     met = {}
@@ -81,6 +81,8 @@ def create_met(base, fn1, fn2):
 
     met['master_slcp'] = os.path.basename(fn1)
     met['slave_slcp'] = os.path.basename(fn2)
+    met['range_looks'] = int(rlooks)
+    met['azimuth_looks'] = int(azlooks)
     return met
 
 def get_vrt_met(prod_dir):
@@ -146,9 +148,11 @@ def parser():
     parse.add_argument("slcp_fn1", help="master SLCP path")
     parse.add_argument("slcp_fn2", help="slave SLCP path")
     parse.add_argument("prod_dir", help="COD product directory path")
+    parse.add_argument("rlooks", help="range looks used")
+    parse.add_argument("azlooks", help="azimuth looks used")
 
     return parse
 
 if __name__ == '__main__':
     args = parser().parse_args()
-    main(args.prod_dir, args.slcp_fn1, args.slcp_fn2)
+    main(args.prod_dir, args.slcp_fn1, args.slcp_fn2, args.rlooks, args.azlooks)

--- a/script/productize.py
+++ b/script/productize.py
@@ -20,7 +20,7 @@ def main(prod_dir, fn1, fn2):
         print('Found no products available for publish in workdir: {}'.format(prod_dir))
         raise Exception('No COD products were generated.')
     base = os.path.basename(prod_dir)
-    met = create_met(base, fn1, fn)
+    met = create_met(base, fn1, fn2)
     dataset = {}
     dataset_path = os.path.join(prod_dir, '{0}.dataset.json'.format(base))
     met_path = os.path.join(prod_dir, '{0}.met.json'.format(base))

--- a/script/productize.py
+++ b/script/productize.py
@@ -71,7 +71,7 @@ def parse_start_end_times(base):
     return times
 
 def create_met(base, fn1, fn2):
-    master_slcp_metfile = os.path.join(fn1, fn1 + '.met.json')
+    master_slcp_metfile = os.path.join(fn1, os.path.basename(fn1) + '.met.json')
     master_slcp_met = load_json(master_slcp_metfile)
     met = {}
     met.update(parse_start_end_times(base))

--- a/script/productize.py
+++ b/script/productize.py
@@ -34,8 +34,7 @@ def main(prod_dir, fn1, fn2):
     dataset['dataset'] = 'S1-COD'
     dataset['label'] = base
     #parse starttime/endtime from name
-    dataset.update(met['starttime'])
-    dataset.update(met['endtime'])
+    dataset.update({'starttime':met['starttime'], 'endtime':met['endtime']})
 
     #parse info from context
     try:
@@ -144,9 +143,9 @@ def parser():
     @return argparse parser
     '''
     parse = argparse.ArgumentParser(description="Generate output COD met and dataset json")
-    parse.add_argument("prod_dir", help="COD product directory path")
     parse.add_argument("slcp_fn1", help="master SLCP path")
     parse.add_argument("slcp_fn2", help="slave SLCP path")
+    parse.add_argument("prod_dir", help="COD product directory path")
 
     return parse
 

--- a/script/slcp2cod_S1.sh
+++ b/script/slcp2cod_S1.sh
@@ -8,6 +8,8 @@ set -e
 dir1=$1
 dir2=$2
 outdir=$3
+rlooks=$4
+azlooks=$5
 
 bdir1=$(basename ${dir1})
 #i=1   # subswath (1, 2, or 3)
@@ -24,21 +26,19 @@ mkdir -p ${outdir}
 cd ${outdir}
 
 #get range/azimuth looks
-nm=$(basename ${dir1})
-metf=${dir1}/${nm}.met.json
+#nm=$(basename ${dir1})
+#metf=${dir1}/${nm}.met.json
 #rlooks=$(cat ${metf} | grep -Po '(?<="range_looks": )(.*?)(?=,)')
 #azlooks=$(cat ${metf} | grep -Po '(?<="azimuth_looks": )(.*?)(?=,)')
 # range looks dependent on subswath
-azlooks=2
-if [ "${i}" -eq "1" ]; then
-    rlooks=7 #subswath 1
-elif [ "${i}" -eq "2" ]; then
-    rlooks=8 #subswath 2
-else
-    rlooks=9 #subswath 3
-fi
-
-
+#azlooks=2
+#if [ "${i}" -eq "1" ]; then
+#    rlooks=7 #subswath 1
+#elif [ "${i}" -eq "2" ]; then
+#    rlooks=8 #subswath 2
+#else
+#    rlooks=9 #subswath 3
+#fi
 
 script_dir=`dirname ${0}`
 ${script_dir}/burst_coherence_diff.py -mdir ${dirm} -sdir ${dirs1} -sdir2 ${dirs2} -gdir ${dirg} -rlks ${rlooks} -alks ${azlooks} -ssize 1.0 || true

--- a/script/slcp2cod_S1.sh
+++ b/script/slcp2cod_S1.sh
@@ -26,17 +26,17 @@ cd ${outdir}
 #get range/azimuth looks
 nm=$(basename ${dir1})
 metf=${dir1}/${nm}.met.json
-#rlooks=$(cat ${metf} | grep -Po '(?<="range_looks": )(.*?)(?=,)')
-#azlooks=$(cat ${metf} | grep -Po '(?<="azimuth_looks": )(.*?)(?=,)')
+rlooks=$(cat ${metf} | grep -Po '(?<="range_looks": )(.*?)(?=,)')
+azlooks=$(cat ${metf} | grep -Po '(?<="azimuth_looks": )(.*?)(?=,)')
 # range looks dependent on subswath
-azlooks=2
-if [ "${i}" -eq "1" ]; then
-    rlooks=7 #subswath 1
-elif [ "${i}" -eq "2" ]; then
-    rlooks=8 #subswath 2
-else
-    rlooks=9 #subswath 3
-fi
+#azlooks=2
+#if [ "${i}" -eq "1" ]; then
+#    rlooks=7 #subswath 1
+#elif [ "${i}" -eq "2" ]; then
+#    rlooks=8 #subswath 2
+#else
+#    rlooks=9 #subswath 3
+#fi
 
 
 

--- a/script/slcp2cod_S1.sh
+++ b/script/slcp2cod_S1.sh
@@ -26,17 +26,17 @@ cd ${outdir}
 #get range/azimuth looks
 nm=$(basename ${dir1})
 metf=${dir1}/${nm}.met.json
-rlooks=$(cat ${metf} | grep -Po '(?<="range_looks": )(.*?)(?=,)')
-azlooks=$(cat ${metf} | grep -Po '(?<="azimuth_looks": )(.*?)(?=,)')
+#rlooks=$(cat ${metf} | grep -Po '(?<="range_looks": )(.*?)(?=,)')
+#azlooks=$(cat ${metf} | grep -Po '(?<="azimuth_looks": )(.*?)(?=,)')
 # range looks dependent on subswath
-#azlooks=2
-#if [ "${i}" -eq "1" ]; then
-#    rlooks=7 #subswath 1
-#elif [ "${i}" -eq "2" ]; then
-#    rlooks=8 #subswath 2
-#else
-#    rlooks=9 #subswath 3
-#fi
+azlooks=2
+if [ "${i}" -eq "1" ]; then
+    rlooks=7 #subswath 1
+elif [ "${i}" -eq "2" ]; then
+    rlooks=8 #subswath 2
+else
+    rlooks=9 #subswath 3
+fi
 
 
 

--- a/script/slcp2cod_wrapper.sh
+++ b/script/slcp2cod_wrapper.sh
@@ -28,11 +28,14 @@ source ${parent_dir}/set_env_variable.sh
 #get subswath
 subswath=$(grep -o "[1-3]" <<< $(grep -o "_s[1-3]-" <<< ${fn1}))
 
+rlooks=$(${script_dir}/get_looks.py ${fn1} 'rn')
+azlooks=$(${script_dir}/get_looks.py ${fn1} 'az')
+
 #run cod script
-${script_dir}/slcp2cod_S1.sh ${fn1} ${fn2} ${fout}
+${script_dir}/slcp2cod_S1.sh ${fn1} ${fn2} ${fout} ${rlooks} ${azlooks}
 
 #productize
-${script_dir}/productize.py ${fn1} ${fn2} ${fout}
+${script_dir}/productize.py ${fn1} ${fn2} ${fout} ${rlooks} ${azlooks}
 
 #remove old dirs
 rm -rf ${fn1}

--- a/script/slcp2cod_wrapper.sh
+++ b/script/slcp2cod_wrapper.sh
@@ -32,7 +32,7 @@ subswath=$(grep -o "[1-3]" <<< $(grep -o "_s[1-3]-" <<< ${fn1}))
 ${script_dir}/slcp2cod_S1.sh ${fn1} ${fn2} ${fout}
 
 #productize
-${script_dir}/productize.py ${fout}
+${script_dir}/productize.py ${fn1} ${fn2} ${fout}
 
 #remove old dirs
 rm -rf ${fn1}


### PR DESCRIPTION
By request from sang-ho: good to have track numbers displayed on FacetSearch.

Gists:
[stderr and stdout](https://gist.github.com/shitong01/cb9415c0478f372fe62551596f35841c)
[product](http://ntu-hysds-dataset.s3-website-ap-southeast-1.amazonaws.com/datasets/coherence_difference/v1.0/2019/04/24/S1-COD_M1S1_TN085_F223_S2_20190412T122027-20190424T122028-20190506T122055-v1.2-standard2)

Faceting on Track and subswath on S1-COD: 
![image](https://user-images.githubusercontent.com/6346909/57672989-03cf7e00-764d-11e9-8824-cd2bc9ac1e91.png)

@jlinick @pymonger 